### PR TITLE
Fix build.sh (EFIboot)

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -245,7 +245,7 @@ make_efi() {
 # Prepare efiboot.img::/EFI for "El Torito" EFI boot mode
 make_efiboot() {
     mkdir -p "${work_dir}/iso/EFI/archiso"
-    truncate -s 100M "${work_dir}/iso/EFI/archiso/efiboot.img"
+    truncate -s 110M "${work_dir}/iso/EFI/archiso/efiboot.img"
     mkfs.fat -n ARCHISO_EFI "${work_dir}/iso/EFI/archiso/efiboot.img"
 
     mkdir -p "${work_dir}/efiboot"


### PR DESCRIPTION
As kernel updates it gets bigger so 100M isnt enough but 110M is
https://media.discordapp.net/attachments/803346245296848949/986891707327078400/unknown.png